### PR TITLE
Add version info to output assembly

### DIFF
--- a/src/DRP.vcxproj
+++ b/src/DRP.vcxproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\GitVersion.MsBuild.5.8.1\build\GitVersion.MsBuild.props" Condition="Exists('packages\GitVersion.MsBuild.5.8.1\build\GitVersion.MsBuild.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -75,6 +76,9 @@
       <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
       <LargeAddressAware>true</LargeAddressAware>
     </Link>
+    <ResourceCompile>
+      <AdditionalOptions>/DGV_FULLSEMVER="%GitVersion_FullSemVer%" %(AdditionalOptions)</AdditionalOptions>
+    </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="resource.h" />
@@ -84,9 +88,20 @@
     <ClCompile Include="main.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
     <ResourceCompile Include="DRP.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="packages\GitVersion.MsBuild.5.8.1\build\GitVersion.MsBuild.targets" Condition="Exists('packages\GitVersion.MsBuild.5.8.1\build\GitVersion.MsBuild.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\GitVersion.MsBuild.5.8.1\build\GitVersion.MsBuild.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\GitVersion.MsBuild.5.8.1\build\GitVersion.MsBuild.props'))" />
+    <Error Condition="!Exists('packages\GitVersion.MsBuild.5.8.1\build\GitVersion.MsBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\GitVersion.MsBuild.5.8.1\build\GitVersion.MsBuild.targets'))" />
+  </Target>
 </Project>

--- a/src/DRP.vcxproj.filters
+++ b/src/DRP.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -26,6 +26,9 @@
     <ClCompile Include="main.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="DRP.rc">

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="GitVersion.MsBuild" version="5.8.1" targetFramework="native" developmentDependency="true" />
+</packages>


### PR DESCRIPTION
Resolves #20

Authorized contributors can contribute to this PR by checking out and pushing to `feat/gitVersion`.

----

## Version.rc resource file

On Windows, the File Version and Product Version properties (as well as others) in a File Properties tab are described by a C++ project's 'Version' resource.
A Version resource can be added to and modified in an existing assembly (EXE/DLL) or written to a project's Version.rc.
To write GitVersion variables to Version.rc before/during Link-time, we'll need to assign the variables to compile-time constants.
The File (GitVersion_FullSemVer) and Product (GitVersion_InformationalVersion) version variables (unless otherwise stated) **must** be assigned in two ways: string data and int-array data (1,0,5,0 (oh god why)). 
**I do not know how the informational version value (string) could be assigned to the Product Version int array, so I hope we don't actually need the int arrays.**

I'd prefer having GitVersion's variables available before and during Link-time so the version information can be tested locally.

----

## Placeholder .NET project
This requires less effort on my end, but may be unusual compared to other C++ projects' methods of versioning.

1. Apply version information to a dotnet project targeting .NET 4.8, build that project before the C++ project
2. Use a certain C++ Linker feature to grab the .NET assembly's version info which the Linker then uses to overwrite the C++ assembly's version info.

----

### Documentation and References
- [declare environment variable as a preprocessor definition](https://stackoverflow.com/a/22828929/14894786)
- [GitVersion variables](https://gitversion.net/docs/reference/variables). When accessed via environment variables or MSBuild properties, these variables are prefixed with `GitVersion_`.